### PR TITLE
ENH: better separator

### DIFF
--- a/layouts/partials/member.html
+++ b/layouts/partials/member.html
@@ -1,5 +1,5 @@
 <tr>
-  <td style="width:80%"><b>{{ .name }}</b> {{ if .title }} ({{ .title}}) {{end}} <br /> <br />
+  <td style="width:80%"><b>{{ .name }}</b> {{ if .title }} ({{ .title}}) {{end}} <br />
   {{ if .scholarId}} <a href="https://scholar.google.com/citations?user={{.scholarId}}"><i class="fa fa-book-open"></i></a>  {{ end }} 
   {{ if .websiteUrl}} <a href="{{.websiteUrl}}"><i class="fa fa-id-badge"></i></a>  {{ end }} 
   <a href="https://github.com/{{.githubId}}"><i class="fab fa-github"></i></a>

--- a/layouts/shortcodes/team.html
+++ b/layouts/shortcodes/team.html
@@ -5,6 +5,15 @@ table, th, td {
    border: none!important;
 }
 
+tr
+{
+     border-bottom: 0.5px solid rgba(0,0,0,0.1);
+}
+tr:last-child
+  {
+       border-bottom: none;
+  }
+
 </style>
 
 <h1> Professors </h1>


### PR DESCRIPTION
Firefox screenshot: 
![image](https://github.com/scilus/scilus_website/assets/10272382/e37b32bd-15f9-4f1d-b0ae-0e39209d4f84)
